### PR TITLE
False trigger re-tap

### DIFF
--- a/Repetier-Firmware-092.2-ERIS-ii2dh/Repetier/Configuration.h
+++ b/Repetier-Firmware-092.2-ERIS-ii2dh/Repetier/Configuration.h
@@ -453,7 +453,7 @@ WARNING: Servos can draw a considerable amount of current. Make sure your system
 #define Z_PROBE_SPEED 50 
 #define Z_PROBE_XY_SPEED 50
 #define Z_PROBE_SWITCHING_DISTANCE 10
-#define Z_PROBE_REPETITIONS 2
+#define Z_PROBE_REPETITIONS 1
 #define Z_PROBE_HEIGHT 0
 //#define Z_PROBE_START_SCRIPT "G28/nG1Z100/n"
 #define Z_PROBE_START_SCRIPT "G1 Z20.0/n"


### PR DESCRIPTION
Set firmware defaults on calibration G-Codes before running
G30 center tap z-height calibration
Double tap each point to detect false triggers if both taps are not
within .1mm of each other.