### PR TITLE
Error Checks

### DIFF
--- a/Repetier-Firmware-092.2-ERIS-ii2dh/Repetier/Commands.cpp
+++ b/Repetier-Firmware-092.2-ERIS-ii2dh/Repetier/Commands.cpp
@@ -831,14 +831,16 @@ void Commands::processGCode(GCode *com)
         Printer::measureDistortion();
         Printer::feedrate = oldFeedrate;
 #else
+        if(com->hasS() && com->S == 2){ // only reset value if saving new value
         Printer::zLength = Z_MAX_LENGTH; // set Z height to firmware default
         EEPROM::storeDataIntoEEPROM(); // store default before calibration
-        
+        }
         Printer::homeAxis(true,true,true);
         GCode::executeFString(Com::tZProbeStartScript);
         bool oldAutolevel = Printer::isAutolevelActive();
         Printer::setAutolevelActive(false);
         float sum = 0, sum1 = 0, sum2 = 0,last,oldFeedrate = Printer::feedrate;
+        int repeats = 1;
         Printer::moveTo(EEPROM::zProbeX1(),EEPROM::zProbeY1(),IGNORE_COORDINATE,IGNORE_COORDINATE,EEPROM::zProbeXYSpeed());
         
         do{
@@ -847,9 +849,17 @@ void Commands::processGCode(GCode *com)
           if ((sum1 - sum) > .1 || (sum1 - sum) < - 0.1){ //tap reports distance, if more or less than .1mm, it will re-run
             sum2 = sum1;
             sum = 0;
+            if (repeats == 5){
+              Com::printErrorFLN(Com::tZProbeFailed);
+              sum = -1;
+              break;
+            }
+            ++repeats;
           }
-          else
+          else{
             sum2 = 0;
+            repeats = 1;
+          }
         } while (sum2 > 0.1); // repeat until taps are within .1 mm
         
         if(sum < 0) break;
@@ -861,9 +871,17 @@ void Commands::processGCode(GCode *com)
           if ((sum1 - last) > .1 || (sum1 - last) < - 0.1){
             sum2 = last;
             last = 0;
+            if (repeats == 5){
+              Com::printErrorFLN(Com::tZProbeFailed);
+              last = -1;
+              break;
+            }
+            ++repeats;
           }
-          else
+          else{
             sum2 = 0;
+            repeats = 1;
+          }
         } while (sum2 > 0.1); // Repeat until both taps are within .1 mm
         
         if(last < 0) break;
@@ -877,9 +895,17 @@ void Commands::processGCode(GCode *com)
           if ((sum1 - last) > .1 || (sum1 - last) < - 0.1){
             sum2 = last;
             last = 0;
+            if (repeats == 5){
+              Com::printErrorFLN(Com::tZProbeFailed);
+              last = -1;
+              break;
+            }
+            ++repeats;
           }
-          else
+          else{
             sum2 = 0;
+            repeats = 1;
+          }
         } while (sum2 > 0.1); // Repeat until both taps are within .1 mm
         
         if(last < 0) break;
@@ -925,14 +951,16 @@ void Commands::processGCode(GCode *com)
         Printer::measureDistortion();
         Printer::feedrate = oldFeedrate;
 #else
+        if(com->hasS() && com->S == 2){ // only reset eeprom if saving new value
         Printer::zLength = Z_MAX_LENGTH; // set Z height to firmware default
         EEPROM::storeDataIntoEEPROM(); // store default before calibration
-        
+        }
         Printer::homeAxis(true,true,true);
         GCode::executeFString(Com::tZProbeStartScript);
         bool oldAutolevel = Printer::isAutolevelActive();
         Printer::setAutolevelActive(false);
         float sum = 0, sum1 = 0, sum2 = 0,last,oldFeedrate = Printer::feedrate;
+        int repeats = 1;
         Printer::moveTo(0,0,IGNORE_COORDINATE,IGNORE_COORDINATE,EEPROM::zProbeXYSpeed());
         
         do{
@@ -941,9 +969,17 @@ void Commands::processGCode(GCode *com)
           if ((sum1 - sum) > .1 || (sum1 - sum) < - 0.1){ //tap reports distance, if more or less than .1mm, it will re-run
             sum2 = sum1;
             sum = 0;
+            if (repeats == 5){
+              Com::printErrorFLN(Com::tZProbeFailed);
+              sum = -1;
+              break;
+            }
+            ++repeats;
           }
-          else
+          else{
             sum2 = 0;
+            repeats = 1;
+          }
         } while (sum2 > 0.1); // repeat until taps are within .1 mm
         
         if(sum < 0) break;
@@ -1064,6 +1100,7 @@ void Commands::processGCode(GCode *com)
         bool oldAutolevel = Printer::isAutolevelActive();
         Printer::setAutolevelActive(false);
         float sum = 0, sum1 = 0, sum2 = 0, last, hradius,oldFeedrate = Printer::feedrate;
+        int repeats = 1;
         Printer::moveTo(0,0,IGNORE_COORDINATE,IGNORE_COORDINATE,EEPROM::zProbeXYSpeed());
         
         do{
@@ -1072,11 +1109,19 @@ void Commands::processGCode(GCode *com)
           if ((sum1 - sum) > .1 || (sum1 - sum) < - 0.1){ //tap reports distance, if more or less than .1mm, it will re-run
             sum2 = sum1;
             sum = 0;
+            if (repeats == 5){
+              Com::printErrorFLN(Com::tZProbeFailed);
+              sum = -1;
+              break;
+            }
+            ++repeats;
           }
-          else
+          else{
             sum2 = 0;
+            repeats = 1;
+          }
         } while (sum2 > 0.1);
-        
+        if(sum < 0) break;
         Printer::moveTo(EEPROM::zProbeX3(),EEPROM::zProbeY3(),IGNORE_COORDINATE,IGNORE_COORDINATE,EEPROM::zProbeXYSpeed());
         
         do{
@@ -1085,11 +1130,19 @@ void Commands::processGCode(GCode *com)
           if ((sum1 - last) > .1 || (sum1 - last) < - 0.1){
             sum2 = last;
             last = 0;
+            if (repeats == 5){
+              Com::printErrorFLN(Com::tZProbeFailed);
+              last = -1;
+              break;
+            }
+            ++repeats;
           }
-          else
+          else{
             sum2 = 0;
+            repeats = 1;
+          }
         } while (sum2 > 0.1); // Repeat until both taps are within .1 mm
-        
+        if(last < 0) break;
         sum = (sum - last)*80;
         if(sum<0) 
         {
@@ -1122,16 +1175,18 @@ void Commands::processGCode(GCode *com)
         Printer::measureDistortion();
         Printer::feedrate = oldFeedrate;
 #else
+        if(com->hasS() && com->S == 2){ // only wipe values if saving the new values
         EEPROM::setDeltaTowerXOffsetSteps(0); // set X offset to 0
         EEPROM::setDeltaTowerYOffsetSteps(0); // set Y offset to 0
         EEPROM::setDeltaTowerZOffsetSteps(0); // set Z offset to 0
         EEPROM::storeDataIntoEEPROM(); // store offsets to 0 before doing anything
-        
+        }
         Printer::homeAxis(true,true,true);
         GCode::executeFString(Com::tZProbeStartScript);
         bool oldAutolevel = Printer::isAutolevelActive();
         Printer::setAutolevelActive(false);
         float sum1 = 0, sum2 = 0, sum = 0, last,oldFeedrate = Printer::feedrate;
+        int repeats = 1;
         Printer::moveTo(EEPROM::zProbeX1(),EEPROM::zProbeY1(),IGNORE_COORDINATE,IGNORE_COORDINATE,EEPROM::zProbeXYSpeed());
        
         do {  
@@ -1140,9 +1195,17 @@ void Commands::processGCode(GCode *com)
           if ((sum1 - sum) > .1 || (sum1 - sum) < - 0.1){ //tap reports distance, if more or less than .1mm, it will re-run
             sum2 = sum1;
             sum = 0;
+            if (repeats == 5){
+              Com::printErrorFLN(Com::tZProbeFailed);
+              sum = -1;
+              break;
+            }
+            ++repeats;
           }
-          else
+          else{
             sum2 = 0;
+            repeats = 1;
+          }
         } while (sum2 > 0.1); // loop to make sure 2 probe repetitions are within 0.1 mm of each other
         
         int32_t offsetX = ((sum * 80) - (Z_PROBE_BED_DISTANCE * 80)), offsetStepsX = EEPROM::deltaTowerXOffsetSteps();
@@ -1155,9 +1218,16 @@ void Commands::processGCode(GCode *com)
           if ((sum1 - last) > .1 || (sum1 - last) < - 0.1){
             sum2 = last;
             last = 0;
+            if (repeats == 5){
+              Com::printErrorFLN(Com::tZProbeFailed); //output to terminal Z probe failure
+              last = -1; // fail flag to stop probe
+              break;
+            }
+            ++repeats;
           }
           else
             sum2 = 0;
+            repeats = 1;
         } while (sum2 > 0.1); // Loop if both taps are not within 0.1 mm
         
         int32_t offsetY = ((last * 80) - (Z_PROBE_BED_DISTANCE * 80)), offsetStepsY = EEPROM::deltaTowerYOffsetSteps();
@@ -1170,9 +1240,17 @@ void Commands::processGCode(GCode *com)
           if((sum1 - last) > .1 || (sum1 - last) < - 0.1){
             sum2 = last;
             last = 0;
+            if (repeats == 5){
+              Com::printErrorFLN(Com::tZProbeFailed); //output to terminal Z probe failure
+              last = -1; // fail flag to stop probe
+              break;
+            }
+            ++repeats;
           }
-          else
+          else{
             sum2 = 0;
+            repeats = 1;
+          } 
         } while (sum2 > 0.1); // Loop if both taps are not within 0.1 mm
         
         int32_t offsetZ = ((last * 80) - (Z_PROBE_BED_DISTANCE * 80)), offsetStepsZ = EEPROM::deltaTowerZOffsetSteps();

--- a/Repetier-Firmware-092.2-ERIS-ii2dh/Repetier/Configuration.h
+++ b/Repetier-Firmware-092.2-ERIS-ii2dh/Repetier/Configuration.h
@@ -443,14 +443,14 @@ WARNING: Servos can draw a considerable amount of current. Make sure your system
 
 #define FEATURE_Z_PROBE 1
 #define Z_PROBE_SENSITIVITY  25 // 0-126 7 bit value  
-#define Z_PROBE_BED_DISTANCE 15
+#define Z_PROBE_BED_DISTANCE 7
 #define Z_PROBE_PIN 16 // mini-rambo ext pins on P3 ext next to LCD header
 #define Z_PROBE_PULLUP 1 //0
 #define Z_PROBE_ON_HIGH 0 //1
 #define Z_PROBE_X_OFFSET 0
 #define Z_PROBE_Y_OFFSET 0
 #define Z_PROBE_WAIT_BEFORE_TEST 0
-#define Z_PROBE_SPEED 50 
+#define Z_PROBE_SPEED 60 
 #define Z_PROBE_XY_SPEED 50
 #define Z_PROBE_SWITCHING_DISTANCE 10
 #define Z_PROBE_REPETITIONS 1
@@ -498,7 +498,7 @@ WARNING: Servos can draw a considerable amount of current. Make sure your system
 #define FEATURE_MEMORY_POSITION 1
 #define FEATURE_CHECKSUM_FORCED 0
 #define FEATURE_FAN_CONTROL 1
-#if PRINTER == 1 || PRINTER == 2
+#if PRINTER == 1 || PRINTER == 2 || PRINTER == 3
 #define FEATURE_CONTROLLER 13
 #else
 #define FEATURE_CONTROLLER 0
@@ -520,7 +520,7 @@ WARNING: Servos can draw a considerable amount of current. Make sure your system
 #define UI_DISABLE_AUTO_PAGESWITCH 1
 #define UI_AUTORETURN_TO_MENU_AFTER 600000
 #define FEATURE_UI_KEYS 0
-#define UI_ENCODER_SPEED 1
+#define UI_ENCODER_SPEED 2
 #define UI_KEY_BOUNCETIME 10
 #define UI_KEY_FIRST_REPEAT 500
 #define UI_KEY_REDUCE_REPEAT 50

--- a/Repetier-Firmware-092.2-ERIS-ii2dh/Repetier/ui.h
+++ b/Repetier-Firmware-092.2-ERIS-ii2dh/Repetier/ui.h
@@ -1082,8 +1082,8 @@ void uiCheckSlowKeys(int &action) {}
 #define UI_DISPLAY_D5_PIN      70
 #define UI_DISPLAY_D6_PIN      85
 #define UI_DISPLAY_D7_PIN      71
-#define UI_ENCODER_A           14
-#define UI_ENCODER_B           72
+#define UI_ENCODER_A           72
+#define UI_ENCODER_B           14
 #define UI_ENCODER_CLICK       9
 #define UI_KILL_PIN           32
 #endif


### PR DESCRIPTION
Eris LCD support pinned for red board LCD
Safety check for probe, after 5 fails, outputs error to terminal and
stops probing.
Set default probe height from 15 to 7 and speed from 50 to 60